### PR TITLE
Split on white to avoid IndexError: list index out of range

### DIFF
--- a/getZookeeperInfo.py
+++ b/getZookeeperInfo.py
@@ -53,7 +53,7 @@ class ZooKeeperCommands(object):
         self._value = {}
         if self._zkCommand == 'mntr':
             for line in self._value_raw.splitlines():
-                parts = line.split('	')
+                parts = line.split()
                 index = parts[0]
                 self._value[index] = parts[1]
         elif self._zkCommand == 'conf':


### PR DESCRIPTION
Hello,

Thanks for your template! Using it on ZK 3.4.5 cdh.

There was a small error on the split for mntr, which caused pretty much everything to not work. The fix is simple, as you can see. Works like a charm like this.

Thank you!
Best,
fred
